### PR TITLE
Register the extension on --require

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,21 +22,13 @@ const DEFAULT_LANGUAGES = [
   'yaml',
 ].join(',');
 
-const hasLanguage = (block) => block.getAttribute('language');
-
 const getDocumentLanguages = (document) => {
   return (document.getAttribute('prism-languages') || DEFAULT_LANGUAGES)
     .split(',')
     .map(lang => lang.trim());
 };
 
-const unescape = html => {
-  return html.replace(/=&gt;/gi, '=>')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>');
-};
-
-module.exports = {
+const PrismExtension = {
   initialize (name, backend, {document}) {
     const languages = getDocumentLanguages(document);
 
@@ -78,8 +70,8 @@ module.exports = {
     return true;
   },
 
-  docinfo () {
-    if (this.backend !== 'html5') {
+  docinfo (location, doc) {
+    if (!doc.isBasebackend('html')) {
       return '';
     }
 
@@ -97,6 +89,9 @@ module.exports = {
   }
 }
 
-module.exports.register = (Extensions) => {
-  console.log(Object.keys(Extensions.$$))
+module.exports = PrismExtension
+module.exports.register = function register (registry) {
+  const AsciidoctorModule = registry.$$base_module
+  const SyntaxHighlighterRegistry = AsciidoctorModule.$$['SyntaxHighlighter']
+  SyntaxHighlighterRegistry.register('prism', PrismExtension)
 }


### PR DESCRIPTION
#### What I Did

- Remove unused function `hasLanguage`
- Remove unused function `unescape`
- Check if the basebackend is `html` instead of cheking if the backend  is `html5` (make it compatible with other HTML-based converters like Asciidoctor Web PDF) 
- Register the syntax highlighter when `register` hook is called (for instance, using `--require asciidoctor-prism-extension` on the CLI)

With these changes I was able to use this syntax highlighter with Asciidoctor Web PDF:

![syntax-highlighting-prism](https://user-images.githubusercontent.com/333276/107149950-b3896b00-695b-11eb-96d6-5b025f73c79f.png)

**presentation.adoc**
```
= Presentation
:source-highlighter: prism
:prism-languages: python
:prism-theme:

== Python


[source,python]
----
from kafka import KafkaProducer
from kafka import KafkaConsumer

# Producer
producer = KafkaProducer(bootstrap_servers="localhost:9092")

for count in range(100):
   producer.send("bus-location", count)

# Consumer
consumer = KafkaConsumer("bus-location")

for msg in consumer:
    print(msg)
----
```

resolves #3 